### PR TITLE
Enable commit-scoped Pages previews on pull requests

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,30 +25,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Download existing Pages site
-        id: fetch_pages
-        continue-on-error: true
-        uses: actions/checkout@v4
-        with:
-          ref: github-pages
-          path: existing-pages
-          fetch-depth: 1
-          persist-credentials: false
-
       - name: Configure Pages
         uses: actions/configure-pages@v5
-
-      - name: Seed prior commit previews
-        run: |
-          set -euo pipefail
-          mkdir -p dist
-
-          if [ -d "existing-pages" ]; then
-            rsync -a --exclude='.git' existing-pages/ dist/
-            echo "Seeded dist/ with existing Pages content"
-          else
-            echo "No existing Pages site found; starting fresh"
-          fi
 
       - name: Prepare commit-scoped artifact
         run: |
@@ -76,10 +54,3 @@ jobs:
           COMMIT_PREVIEW_URL="${{ steps.deployment.outputs.page_url }}${{ env.COMMIT_ID }}/"
           echo "Commit preview: ${COMMIT_PREVIEW_URL}"
           echo "Commit preview URL: ${COMMIT_PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"
-          printf "%s\n" "${COMMIT_PREVIEW_URL}" > commit-preview-url.txt
-
-      - name: Upload commit preview URL artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: commit-preview-url
-          path: commit-preview-url.txt


### PR DESCRIPTION
## Summary
- trigger the Pages deployment workflow on pull request events instead of only pushes to main
- package the static site into a commit-scoped subdirectory so each commit gets its own preview path
- adjust concurrency grouping to prevent different PR runs from canceling one another

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69456eb7c94083249f2cc336e0d4b286)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Trigger Pages on pull requests and deploy commit-scoped artifacts to `dist/<commit_sha>`, seeding from existing site, updating concurrency, and publishing a per-commit preview URL.
> 
> - **GitHub Actions workflow (`.github/workflows/deploy-pages.yml`)**:
>   - **Triggers**: Run on `pull_request` events (opened/synchronize/reopened/ready_for_review).
>   - **Concurrency**: Scope group to `pages-${{ github.event.pull_request.number || github.ref }}` to avoid cross-PR cancellations.
>   - **Commit-scoped deploys**:
>     - Set `COMMIT_ID` to PR head SHA; checkout that ref.
>     - Fetch existing `github-pages` branch into `existing-pages` and seed `dist/` via `rsync`.
>     - Package site into `dist/${COMMIT_ID}` by copying `index.html`, `style.css`, `scripts.js`, and `assets/`.
>     - Upload `dist` as Pages artifact (was repo root) and deploy.
>     - Post-deploy, compute and output commit preview URL; upload it as an artifact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad8c931076a7b202060d8ec6b870cdc1022fa884. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->